### PR TITLE
fix: enter key behavior on virtual keyboard to prevent premature guess submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,6 @@
           <div class="box"></div>
         </div>
       </div>
-      <div class="virtual-keyboard"></div>
     </main>
   </body>
 </html>

--- a/src/controllers/input.js
+++ b/src/controllers/input.js
@@ -1,0 +1,76 @@
+import Buffer from "../services/buffer.js";
+import VirtualKeyboard from "../modules/virtual-keyboard.js";
+import { isBackSpace, isEnter, isLetter, layout } from "../modules/keyboard.js";
+
+const defaultLanguage = "en"; // English
+
+let _onInput = (buffer) => console.info("Buffer.onChange->", buffer.getValue());
+let _onEnter = (buffer) => console.info("Buffer.onEnter->", buffer.getValue());
+
+const isActiveElementVirtual = () =>
+  document.activeElement.classList.contains("virtual-key");
+
+const removeActiveElementFocus = () => document.activeElement.blur();
+
+const processLetterKey = (key, virtual) => {
+  // When the key pressed is a physical key
+  // and previous focused key is virtual,
+  // remove the focus of that key element.
+  if (!virtual && isActiveElementVirtual()) {
+    removeActiveElementFocus();
+  }
+
+  Buffer.push(key);
+
+  _onInput(Buffer);
+};
+
+const processBackspaceKey = () => {
+  Buffer.pop();
+
+  _onInput(Buffer);
+};
+
+const processEnterKey = (virtual) => {
+  // If the physical Enter key is pressed over a focused virtual key,
+  // do nothing, as the virtual key will be processed on its own.
+  // This prevents accidental premature submission of a guess
+  // while entering letters on the virtual keyboard.
+  if (!virtual && isActiveElementVirtual()) {
+    return;
+  }
+
+  _onEnter(Buffer);
+};
+
+const processKey = (key, virtual = false) => {
+  if (isLetter(key)) {
+    processLetterKey(key, virtual);
+  } else if (isBackSpace(key)) {
+    processBackspaceKey();
+  } else if (isEnter(key)) {
+    processEnterKey(virtual);
+  }
+};
+
+const init = ({ onInput, onEnter, language = defaultLanguage }) => {
+  // virtual keyboard
+  document
+    .querySelector(".main")
+    .appendChild(
+      VirtualKeyboard.create(layout[language], (key) => processKey(key, true))
+    );
+
+  // physical keyboard
+  document.addEventListener("keyup", (event) => {
+    event.preventDefault();
+    processKey(event.key);
+  });
+
+  // subscribers
+  // TODO: implement an observer pattern for this?
+  _onInput = "function" === typeof onInput ? onInput : _onInput;
+  _onEnter = "function" === typeof onEnter ? onEnter : _onEnter;
+};
+
+export default { init };

--- a/src/controllers/wordless.js
+++ b/src/controllers/wordless.js
@@ -1,5 +1,5 @@
 import Game from "../modules/game.js";
-import Keyboard from "../modules/keyboard.js";
+import Input from "./input.js";
 import UI from "../modules/ui.js";
 
 const handleSubmitSuccess = (buffer, feedback) => {
@@ -78,7 +78,7 @@ const start = async () => {
   startLoading();
 
   try {
-    Keyboard.init({
+    Input.init({
       onInput: (buffer) => handleOnInput(buffer),
       onEnter: (buffer) => handleOnEnter(buffer),
     });

--- a/src/modules/keyboard.js
+++ b/src/modules/keyboard.js
@@ -1,3 +1,7 @@
+export const layout = {
+  en: "qwertyuiop\nasdfghjkl\nEzxcvbnmB",
+};
+
 export const isLetter = (key) => /^[A-Za-z\u00f1\u00d1]$/.test(key);
 
 export const isBackSpace = (key) => key === "Backspace";

--- a/src/modules/keyboard.js
+++ b/src/modules/keyboard.js
@@ -1,48 +1,5 @@
-import Buffer from "../services/buffer.js";
-import VirtualKeyboard from "../modules/virtual-keyboard.js";
-import { en } from "../services/keyboard-layout.js";
+export const isLetter = (key) => /^[A-Za-z\u00f1\u00d1]$/.test(key);
 
-const isLetter = (key) => /^[A-Za-z\u00f1\u00d1]$/.test(key);
+export const isBackSpace = (key) => key === "Backspace";
 
-const isBackSpace = (key) => key === "Backspace";
-
-const isEnter = (key) => key === "Enter";
-
-const processKey = (onInput, onEnter) => (key) => {
-  if (isLetter(key)) {
-    Buffer.push(key);
-    onInput(Buffer);
-  } else if (isBackSpace(key)) {
-    Buffer.pop();
-    onInput(Buffer);
-  } else if (isEnter(key)) {
-    onEnter(Buffer);
-  }
-};
-
-const handleKey = (onInput, onEnter) => (event) => {
-  event.preventDefault();
-
-  processKey(onInput, onEnter)(event.key);
-};
-
-const handleVirtualKey = (onInput, onEnter) => (event) => {
-  event.preventDefault();
-
-  if (event.target instanceof HTMLButtonElement) {
-    processKey(onInput, onEnter)(event.target.dataset.key);
-  }
-};
-
-const init = ({ onInput, onEnter }) => {
-  VirtualKeyboard.render(
-    en,
-    document.querySelector(".virtual-keyboard"),
-    handleVirtualKey(onInput, onEnter)
-  );
-  document.addEventListener("keyup", handleKey(onInput, onEnter));
-};
-
-export default {
-  init,
-};
+export const isEnter = (key) => key === "Enter";

--- a/src/modules/virtual-keyboard.js
+++ b/src/modules/virtual-keyboard.js
@@ -1,19 +1,22 @@
-const createKeyButton = (key) => {
+const createVirtualKey = (key) => {
   const btn = document.createElement("button");
 
-  btn.classList.add("button", "key");
+  btn.classList.add("virtual-key");
 
-  if ("E" === key) {
-    btn.textContent = "Enter";
-    btn.dataset.key = "Enter";
-    btn.classList.add("special");
-  } else if ("B" === key) {
-    btn.textContent = "Del";
-    btn.dataset.key = "Backspace";
-    btn.classList.add("special");
-  } else {
-    btn.textContent = key;
-    btn.dataset.key = key;
+  switch (key) {
+    case /* Enter */ "E":
+      btn.textContent = "Enter";
+      btn.dataset.key = "Enter";
+      btn.classList.add("special");
+      break;
+    case /* Backspace */ "B":
+      btn.textContent = "Del";
+      btn.dataset.key = "Backspace";
+      btn.classList.add("special");
+      break;
+    default: /* letter */
+      btn.textContent = key;
+      btn.dataset.key = key;
   }
 
   return btn;
@@ -24,23 +27,31 @@ const createKeyRow = (keys) => {
 
   keyRow.classList.add("key-row");
 
-  keyRow.append(...keys.split("").map(createKeyButton));
+  keyRow.append(...keys.split("").map(createVirtualKey));
 
   return keyRow;
 };
 
-const render = (layout, parent, onClick) => {
-  const keyboard = document.createElement("div");
+const createKeyboardLayout = (layout) => {
+  const keyboardLayout = document.createElement("div");
 
-  keyboard.classList.add("keyboard-layout");
+  keyboardLayout.classList.add("keyboard-layout");
 
-  keyboard.append(...layout.split("\n").map(createKeyRow));
+  keyboardLayout.append(...layout.split("\n").map(createKeyRow));
 
-  keyboard.addEventListener("click", onClick);
+  return keyboardLayout;
+};
 
-  parent.appendChild(keyboard);
+const create = (layout) => {
+  const virtualKeyboard = document.createElement("div");
+
+  virtualKeyboard.classList.add("virtual-keyboard");
+
+  virtualKeyboard.appendChild(createKeyboardLayout(layout));
+
+  return virtualKeyboard;
 };
 
 export default {
-  render,
+  create,
 };

--- a/src/modules/virtual-keyboard.js
+++ b/src/modules/virtual-keyboard.js
@@ -42,12 +42,20 @@ const createKeyboardLayout = (layout) => {
   return keyboardLayout;
 };
 
-const create = (layout) => {
+const create = (layout, onKeyPressed) => {
   const virtualKeyboard = document.createElement("div");
 
   virtualKeyboard.classList.add("virtual-keyboard");
 
   virtualKeyboard.appendChild(createKeyboardLayout(layout));
+
+  virtualKeyboard.addEventListener("click", (event) => {
+    event.preventDefault();
+
+    if (event.target.classList.contains("virtual-key")) {
+      onKeyPressed(event.target.dataset.key);
+    }
+  });
 
   return virtualKeyboard;
 };

--- a/src/services/keyboard-layout.js
+++ b/src/services/keyboard-layout.js
@@ -1,1 +1,0 @@
-export const en = "qwertyuiop\nasdfghjkl\nEzxcvbnmB";

--- a/style/virtual-keyboard.css
+++ b/style/virtual-keyboard.css
@@ -30,7 +30,7 @@
 
 /* Keyboard keys */
 
-.key-row > .button.key {
+.key-row > .virtual-key {
   background-color: var(--light-gray);
   border-radius: 3px;
   border: 0;
@@ -46,7 +46,7 @@
   user-select: none;
 }
 
-.key-row > .special.button.key {
+.key-row > .special.virtual-key {
   font-size: 85%;
   font-weight: normal;
   min-width: 3rem;
@@ -58,12 +58,12 @@
 @media (min-width: 375px) {
   /* Responsive keyboard keys */
 
-  .key-row > .button.key {
+  .key-row > .virtual-key {
     min-height: 3rem;
     min-width: 2rem;
   }
 
-  .key-row > .special.button.key {
+  .key-row > .special.virtual-key {
     font-size: 90%;
     min-width: 3.5rem;
   }


### PR DESCRIPTION
Fix premature guess when using virtual keyboard with physical keyboard by pressing Tab to move across the different keys and pressing Enter to enter the letter. Pressing Enter over a focused virtual key will only "type" that key, but it won't submit the guess.

### Changelog

- Refactor keyboard and virtual keyboard modules.
- Implement a new Input controller

### Demo

> Entering the letters by using the virtual keyboard with the physical keyboard does not trigger a premature submission when pressing the Enter key

![demo](https://github.com/syntacticnewman/wordless/assets/146788478/3f56b971-a347-4ffa-8bf9-af8a77a0a1d5)

### Other Recordings (regression testing)

#### When using only the physical keyboard

> Player enters, deletes and submits the letters by using only the physical keyboard

![using-physical-keyboard](https://github.com/syntacticnewman/wordless/assets/146788478/19215274-001a-4aec-8066-36f36b96cb54)

#### When using the virtual keyboard with a mouse

> Player enters, deletes and submit the letters by using the mouse on the virtual keyboard

![using-virtual-keyboard-with-mouse](https://github.com/syntacticnewman/wordless/assets/146788478/a3cc14c1-8e9e-4841-be5b-3107a90d8a70)

#### When using the virtual keyboard with a physical keyboard

> Player enters, deletes and submits the letters by using the virtual keyboard with the physical keyboard by navigating through the keys by pressing the Tab key and by entering the letters by pressing the Enter key

![using-virtual-keyboard-with-tab-and-enter](https://github.com/syntacticnewman/wordless/assets/146788478/be7d222b-93c3-4e0a-a2cb-d2cbc82f3be5)

#### When using the virtual keyboard with a physical keyboard switching back and forth

> Player enters, deletes and submits the letters by using the virtual keyboard but also with the physical keyboard. This is how it works, when player presses Tab it focuses the virtual keyboard, so then the player can navigate through the virtual keys by pressing the Tab key repeatedly and enter them by pressing the Enter key, but if the user types a (physical) letter using the physical keyboard, then the focus from the virtual keyboard is lost so that the player uses the physical keyboard as normal until it presses the Tab key again to switch back to the virtual keyboard.

![using-both-physical-keyboard-and-virtual-keyboard](https://github.com/syntacticnewman/wordless/assets/146788478/a06d9ea3-1119-42dd-883a-600e9bff3812)


