### PR TITLE
feat: auto rescale the board size

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -12,8 +12,6 @@
   --serif: "Suez One", serif;
   --sans: "Secular One", sans-serif;
   --font-size: 1rem;
-  /* Box */
-  --box-size: 56px;
   /* Animation */
   --typing-speed: 50ms;
   --flip-speed: 0.5s;

--- a/style/game.css
+++ b/style/game.css
@@ -56,32 +56,32 @@ header h1 span.gray {
 .table {
   display: grid;
   gap: 5px;
-  grid-template-columns: 1fr;
-  grid-template-rows: 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-rows: repeat(6, 1fr);
   justify-items: center;
 }
 
 .row {
   display: grid;
   gap: 5px;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-  grid-template-rows: 1fr;
+  grid-template-columns: repeat(5, 1fr);
 }
 
 .box {
   align-items: center;
+  aspect-ratio: 1;
   border-radius: 3px;
   border: 1px solid var(--light-gray);
   display: flex;
-  height: var(--box-size);
+  height: 100%;
   justify-content: center;
-  width: var(--box-size);
 }
 
 /* Styles for board */
 
 .board {
+  flex-basis: 100%;
   margin: 0 auto;
+  max-height: 385px;
   padding: 1rem 0;
 }
 
@@ -147,7 +147,16 @@ header h1 span.gray {
 virtual-keyboard {
   align-items: flex-end;
   display: flex;
-  flex-basis: 100%;
   justify-content: center;
   padding-bottom: 1rem;
+}
+
+/* Responsive min-width: 375px */
+
+@media (min-width: 375px) {
+  /* Responsive board */
+
+  .board {
+    max-height: 500px;
+  }
 }


### PR DESCRIPTION
## Screenshots

### Screen size 320 x 600

**Before/After:**

<img width="240" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/79d9282f-4587-4ae4-92c7-e9d85e7c5132">
<img width="240" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/e1f5aa07-d2a1-43a5-a00c-437ae5a46e92">

### Screen size 375 x 667 (iPhone SE)

**Before/After:**

<img width="280" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/bd8a1240-b6aa-4cfc-be95-6732a0230eb8">
<img width="280" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/0554a2d6-8bfe-4b56-983e-09063f56eb8a">

### Screen size 430 x 932 (iPhone 14 Pro Max)

**Before/After:**

<img width="216" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/b96396d0-3693-4ee1-83c4-421b394a0ded">
<img width="216" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/990ad172-09ce-4db9-af11-3720753499b8">

### Screen size 760 x 700 (Tablet)

**Before/After:**

<img width="383" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/9841cbb8-5e21-4869-99f8-ac0ca0e2783a">
<img width="383" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/387a5568-c038-43c7-ac81-380127ed472e">

### Screen size 1024 x 800 (Laptop)

**Before/After:**

<img width="512" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/82c2ea42-0e3e-448d-b6f5-54c3e3fe4624">
<img width="512" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/af2cad2f-4704-4625-994d-404be599e24c">


