### PR TITLE
fix: keep space for the virtual keyboard while it loads

### DIFF
--- a/style/game.css
+++ b/style/game.css
@@ -149,7 +149,7 @@ virtual-keyboard {
   display: flex;
   justify-content: center;
   padding-bottom: 1rem;
-  min-height: 170px;
+  min-height: 146px;
 }
 
 /* Responsive min-width: 375px */
@@ -159,5 +159,11 @@ virtual-keyboard {
 
   .board {
     max-height: 500px;
+  }
+
+  /* Responsive Virtual Keyboard */
+
+  virtual-keyboard {
+    min-height: 170px;
   }
 }

--- a/style/game.css
+++ b/style/game.css
@@ -149,6 +149,7 @@ virtual-keyboard {
   display: flex;
   justify-content: center;
   padding-bottom: 1rem;
+  min-height: 170px;
 }
 
 /* Responsive min-width: 375px */


### PR DESCRIPTION
## Screenshots

**Before/After:**

<img width="300" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/f9a69c27-0fa9-4a7e-8aed-ca49a599df27">
<img width="300" alt="image" src="https://github.com/syntacticnewman/wordless/assets/146788478/73190a52-3d3a-4551-bfdc-895e10c9f8c4">
