### PR TITLE
feat: deactivate animations on reduced motion preference

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -51,3 +51,11 @@ h2,
 h3 {
   margin: 0;
 }
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+  }
+}


### PR DESCRIPTION
## Demo

When `prefers-reduced-motion` is activated, animations and transitions are disabled:

![without-animation](https://github.com/user-attachments/assets/293367e8-6ae1-4568-a821-58a2891c27ba)

When `prefers-reduced-motion` is NOT activated, animations and transitions are kept:

![with-animation](https://github.com/user-attachments/assets/a7258221-0672-4fdd-a699-28e3fe0dfa7c)
