### PR TITLE
fix: board styles for firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,43 +55,43 @@
       </nav>
     </header>
     <main class="main">
-      <div class="board table">
-        <div class="guess row">
+      <div class="board">
+        <div class="row">
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
         </div>
-        <div class="guess row">
+        <div class="row">
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
         </div>
-        <div class="guess row">
+        <div class="row">
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
         </div>
-        <div class="guess row">
+        <div class="row">
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
         </div>
-        <div class="guess row">
+        <div class="row">
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>
         </div>
-        <div class="guess row">
+        <div class="row">
           <div class="box"></div>
           <div class="box"></div>
           <div class="box"></div>

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -26,9 +26,9 @@ const queryAboutDialogCloseBtn = () =>
   document.querySelector(".about-dialog-close-btn");
 
 /**
- * Returns all rows (guesses).
+ * Returns all rows.
  */
-const queryAllRows = () => document.querySelectorAll(".guess.row");
+const queryAllRows = () => document.querySelectorAll(".row");
 
 /**
  * Returns a single row by index.
@@ -36,7 +36,7 @@ const queryAllRows = () => document.querySelectorAll(".guess.row");
 const queryRow = (index) => queryAllRows().item(index);
 
 /**
- * Returns all boxes (letters) within a row (guess).
+ * Returns all boxes (letters) within a row.
  */
 const queryBoxes = (row) => row.querySelectorAll(".box");
 

--- a/style/game.css
+++ b/style/game.css
@@ -47,6 +47,7 @@
 }
 
 /* Navbar */
+
 .nav {
   position: absolute;
   right: 1rem;
@@ -60,39 +61,14 @@
   height: calc(100% - var(--header-height));
 }
 
-/* Table Layout */
-
-.table {
-  display: grid;
-  gap: 5px;
-  grid-template-rows: repeat(6, 1fr);
-  justify-items: center;
-}
-
-/* Row Layout */
-
-.row {
-  display: grid;
-  gap: 5px;
-  grid-template-columns: repeat(5, 1fr);
-}
-
-/* Box Layout */
-
-.box {
-  align-items: center;
-  aspect-ratio: 1;
-  border-radius: 3px;
-  border: 1px solid var(--light-gray);
-  display: flex;
-  height: 100%;
-  justify-content: center;
-}
-
 /* Game Board */
 
 .board {
+  display: grid;
   flex-basis: 100%;
+  gap: 5px;
+  grid-template-rows: repeat(6, 1fr);
+  justify-items: center;
   margin: 0 auto;
   max-height: 385px;
   padding: 1rem 0;
@@ -105,6 +81,12 @@
 }
 
 /* Guess Row */
+
+.row {
+  display: grid;
+  gap: 5px;
+  grid-template-columns: repeat(5, 1fr);
+}
 
 .guess--invalid {
   animation: shake var(--shake-speed) cubic-bezier(0.22, 0.61, 0.36, 1);
@@ -125,7 +107,17 @@
   animation-timing-function: ease-in-out;
 }
 
-/* Letter */
+/* Letter Box */
+
+.box {
+  align-items: center;
+  aspect-ratio: 1;
+  border-radius: 3px;
+  border: 1px solid var(--light-gray);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
 
 .letter {
   animation: typing var(--typing-speed) ease-out;

--- a/style/game.css
+++ b/style/game.css
@@ -64,6 +64,7 @@
 /* Game Board */
 
 .board {
+  aspect-ratio: 5/6;
   display: grid;
   flex-basis: 100%;
   gap: 5px;
@@ -71,7 +72,8 @@
   justify-items: center;
   margin: 0 auto;
   max-height: 385px;
-  padding: 1rem 0;
+  min-height: 385px;
+  padding: 1rem;
 }
 
 @media screen and (min-width: 375px) {
@@ -86,6 +88,7 @@
   display: grid;
   gap: 5px;
   grid-template-columns: repeat(5, 1fr);
+  width: 100%;
 }
 
 .guess--invalid {
@@ -111,11 +114,9 @@
 
 .box {
   align-items: center;
-  aspect-ratio: 1;
   border-radius: 3px;
   border: 1px solid var(--light-gray);
   display: flex;
-  height: 100%;
   justify-content: center;
 }
 


### PR DESCRIPTION
## Demo

### Before/After (Firefox):

<img width="320" alt="before-firebox" src="https://github.com/user-attachments/assets/f9d3f50f-dcb8-43d0-91e1-a5f2ec7f741b">
<img width="320" alt="after-firefox" src="https://github.com/user-attachments/assets/dba2ee90-6618-461f-ae45-b9f27cf65b42">


### Before/After (Safari):

<img width="320" alt="before-safari" src="https://github.com/user-attachments/assets/4144e49c-534c-4fcb-8fe6-8df02a63577f">
<img width="320" alt="after-safari" src="https://github.com/user-attachments/assets/47b49e1a-ff31-4272-aad8-a462cf59683d">

### Before/After (Chrome):

<img width="320" alt="before-chrome" src="https://github.com/user-attachments/assets/eb53d0c4-fa0b-49c4-87fe-b0a080fe2faf">
<img width="320" alt="after-chrome" src="https://github.com/user-attachments/assets/d83f577b-e30b-42a6-9b31-61293f42f14e">


