### PR TITLE
feat: esc key should close about modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <!-- This prevents FOUC for the virtual keyboard -->
     <link
       rel="preload"
-      href="./src/components/virtual-keyboard.css"
+      href="./src/ui/components/virtual-keyboard/styles.css"
       as="style"
     />
     <!-- Game styles -->

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <span class="gray">s</span>
       </h1>
       <nav class="nav">
-        <button class="about-dialog-show-btn" aria-label="About" title="About">
+        <button class="about-modal-show-btn" aria-label="About" title="About">
           <span aria-hidden="true">?</span>
         </button>
       </nav>
@@ -101,10 +101,10 @@
       </div>
       <virtual-keyboard />
     </main>
-    <dialog class="about-dialog">
-      <header class="about-dialog-header">
+    <dialog class="about-modal">
+      <header class="about-modal-header">
         <h2>About Wordless</h2>
-        <button class="about-dialog-close-btn" aria-label="Close" title="Close">
+        <button class="about-modal-close-btn" aria-label="Close" title="Close">
           <span aria-hidden="true">x</span>
         </button>
       </header>

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -48,9 +48,9 @@ const trackGameOver = (isAWin, numberOfTries) => {
   );
 };
 
-const trackAboutDialog = (isOpen) => {
+const trackAboutModal = (isOpen) => {
   track(
-    "about_dialog",
+    "about_modal",
     getEventParams({
       category: CATEGORY.ABOUT_GAME,
       label: "open",
@@ -59,4 +59,4 @@ const trackAboutDialog = (isOpen) => {
   );
 };
 
-export default { trackGuessSubmission, trackGameOver, trackAboutDialog };
+export default { trackGuessSubmission, trackGameOver, trackAboutModal };

--- a/src/ui/components/index.js
+++ b/src/ui/components/index.js
@@ -1,4 +1,4 @@
-import VirtualKeyboard from "../components/virtual-keyboard.js";
+import VirtualKeyboard from "./virtual-keyboard/index.js";
 
 export const loadCustomComponents = () => {
   // define <virtual-keyboard> component

--- a/src/ui/components/virtual-keyboard/i18n.js
+++ b/src/ui/components/virtual-keyboard/i18n.js
@@ -1,0 +1,6 @@
+export const defaultLanguage = "en"; // English
+
+export const LAYOUT = {
+  en: "qwertyuiop\nasdfghjkl\nBzxcvbnmE",
+  es: "qwertyuiop\nasdfghjklñ\nBzxcvbnmE",
+};

--- a/src/ui/components/virtual-keyboard/icons/backspace-icon.js
+++ b/src/ui/components/virtual-keyboard/icons/backspace-icon.js
@@ -1,0 +1,2 @@
+// Designed by https://iconduck.com/designers/arturo-wibawa
+export const backspaceIcon = `<svg fill="none" height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="var(--key-color)" stroke-linecap="round" stroke-width="2"><path d="m17 15-6-6m6 0-6 6"/><path d="M7.4 4.8A2 2 0 0 1 9 4h11a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H9a2 2 0 0 1-1.6-.8l-4.5-6a2 2 0 0 1 0-2.4z" stroke-linejoin="round"/></g></svg>`;

--- a/src/ui/components/virtual-keyboard/index.js
+++ b/src/ui/components/virtual-keyboard/index.js
@@ -1,0 +1,1 @@
+export { default } from "./virtual-keyboard.js";

--- a/src/ui/components/virtual-keyboard/styles.css
+++ b/src/ui/components/virtual-keyboard/styles.css
@@ -1,5 +1,5 @@
 :host {
-  /* Key Colors */
+  /* Keyboard Key Colors */
   --key-bg-color: var(--vk-key-bg-color, lightgray);
   --key-color: var(--vk-key-color, black);
   --key-correct-color: var(--vk-key-correct-color, limegreen);

--- a/src/ui/components/virtual-keyboard/utils.js
+++ b/src/ui/components/virtual-keyboard/utils.js
@@ -1,12 +1,8 @@
-const defaultLanguage = "en"; // English
+import { backspaceIcon } from "./icons/backspace-icon.js";
 
-const LAYOUT = {
-  en: "qwertyuiop\nasdfghjkl\nBzxcvbnmE",
-};
-
-// Designed by https://iconduck.com/designers/arturo-wibawa
-const backspaceIcon = `<svg fill="none" height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="var(--black)" stroke-linecap="round" stroke-width="2"><path d="m17 15-6-6m6 0-6 6"/><path d="M7.4 4.8A2 2 0 0 1 9 4h11a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H9a2 2 0 0 1-1.6-.8l-4.5-6a2 2 0 0 1 0-2.4z" stroke-linejoin="round"/></g></svg>`;
-
+/**
+ * Creates the button for the virtual key.
+ */
 const createVirtualKey = (key) => {
   const virtualKey = document.createElement("button");
 
@@ -34,6 +30,10 @@ const createVirtualKey = (key) => {
   return virtualKey;
 };
 
+/**
+ * Creates the container row for the virtual keys.
+ * @example Q W E R T Y
+ */
 const createKeyRow = (keys) => {
   const keyRow = document.createElement("div");
 
@@ -44,6 +44,13 @@ const createKeyRow = (keys) => {
   return keyRow;
 };
 
+/**
+ * Creates the container layout for the keyboard rows.
+ * @example
+ * Q W E R T Y
+ *  A S D F
+ *   Z X C
+ */
 const createKeyboardLayout = (layout) => {
   const keyboardLayout = document.createElement("div");
 
@@ -54,7 +61,11 @@ const createKeyboardLayout = (layout) => {
   return keyboardLayout;
 };
 
-const createVirtualKeyboard = (layout) => {
+/**
+ * Creates the main container for the Virtual Keyboard
+ * and sets up the event listener fo click events.
+ */
+export const createVirtualKeyboard = (layout) => {
   const virtualKeyboard = document.createElement("div");
 
   virtualKeyboard.classList.add("virtual-keyboard");
@@ -80,7 +91,7 @@ const createVirtualKeyboard = (layout) => {
   return virtualKeyboard;
 };
 
-const addKeyboardNavigation = (root) => {
+export const addKeyboardNavigation = (root) => {
   /**
    * All virtual keys in the virtual keyboard.
    */
@@ -104,7 +115,7 @@ const addKeyboardNavigation = (root) => {
     keys[(index - 1 + keys.length) % keys.length];
 
   /**
-   * When Tab, returns the next key, or the previous one if Shift is pressed.
+   * When Tab, returns the next key, or the previous while the Shift key is hold.
    */
   const getNextKey = (current, shiftKey) => {
     if (shiftKey) {
@@ -197,36 +208,3 @@ const addKeyboardNavigation = (root) => {
     }
   });
 };
-
-class VirtualKeyboard extends HTMLElement {
-  constructor() {
-    super();
-
-    this.language = document.documentElement.lang;
-
-    // Use the layout in the document's language or the layout in English as a fallback.
-    this.layout = LAYOUT[this.language] ?? LAYOUT[defaultLanguage];
-
-    // Setting `delegatesFocus` to true helps in Firefox to remove focus
-    // when `document.activeElement.blur()` is called.
-    this.root = this.attachShadow({ mode: "open", delegatesFocus: true });
-
-    this.loadCSS();
-  }
-
-  loadCSS() {
-    const stylesLink = document.createElement("link");
-
-    stylesLink.setAttribute("rel", "stylesheet");
-    stylesLink.setAttribute("href", "src/components/virtual-keyboard.css");
-
-    this.root.appendChild(stylesLink);
-  }
-
-  connectedCallback() {
-    this.root.appendChild(createVirtualKeyboard(this.layout));
-    addKeyboardNavigation(this.root);
-  }
-}
-
-export default VirtualKeyboard;

--- a/src/ui/components/virtual-keyboard/virtual-keyboard.js
+++ b/src/ui/components/virtual-keyboard/virtual-keyboard.js
@@ -1,0 +1,37 @@
+import { LAYOUT, defaultLanguage } from "./i18n.js";
+import { createVirtualKeyboard, addKeyboardNavigation } from "./utils.js";
+
+class VirtualKeyboard extends HTMLElement {
+  constructor() {
+    super();
+
+    this.layout = this.getLayout(document.documentElement.lang);
+
+    // setting `delegatesFocus` to true fixes issue with Firefox
+    // to remove the focus when `document.activeElement.blur()` is called.
+    this.root = this.attachShadow({ mode: "open", delegatesFocus: true });
+
+    this.loadCSS("src/ui/components/virtual-keyboard/styles.css");
+  }
+
+  connectedCallback() {
+    this.root.appendChild(createVirtualKeyboard(this.layout));
+    addKeyboardNavigation(this.root);
+  }
+
+  getLayout(language) {
+    // use the language provided or the default language (English) as a fallback to choose the correct layout.
+    return LAYOUT[language] ?? LAYOUT[defaultLanguage];
+  }
+
+  loadCSS(url) {
+    const stylesLink = document.createElement("link");
+
+    stylesLink.setAttribute("rel", "stylesheet");
+    stylesLink.setAttribute("href", url);
+
+    this.root.appendChild(stylesLink);
+  }
+}
+
+export default VirtualKeyboard;

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -5,8 +5,8 @@ import { initAboutModal } from "./modals.js";
 const init = () => {
   // initialize modals
   initAboutModal({
-    onShow: () => GA.trackAboutDialog(true),
-    onClose: () => GA.trackAboutDialog(false),
+    onShow: () => GA.trackAboutModal(true),
+    onClose: () => GA.trackAboutModal(false),
   });
 
   // load custom components

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,6 +1,6 @@
 import GA from "../services/analytics.js";
+import { loadCustomComponents } from "./components/index.js";
 import { initAboutModal } from "./modals.js";
-import { loadCustomComponents } from "./components.js";
 
 const init = () => {
   // initialize modals

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -1,3 +1,4 @@
+import Keyboard from "../modules/keyboard.js";
 import {
   queryAboutModal,
   queryShowAboutModalBtn,
@@ -16,6 +17,13 @@ export const initAboutModal = ({ onShow, onClose }) => {
 
   closeAboutModalBtn.addEventListener("click", () => {
     aboutModal.close();
+  });
+
+  aboutModal.addEventListener("keydown", (event) => {
+    if (Keyboard.isEsc(event.key)) {
+      event.stopPropagation();
+      aboutModal.close();
+    }
   });
 
   aboutModal.addEventListener("close", () => {

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -1,24 +1,24 @@
 import {
-  queryAboutDialog,
-  queryAboutDialogShowBtn,
-  queryAboutDialogCloseBtn,
+  queryAboutModal,
+  queryShowAboutModalBtn,
+  queryCloseAboutModalBtn,
 } from "./queries.js";
 
 export const initAboutModal = ({ onShow, onClose }) => {
-  const aboutDialog = queryAboutDialog();
-  const showAboutDialogButton = queryAboutDialogShowBtn();
-  const closeAboutDialogButton = queryAboutDialogCloseBtn();
+  const aboutModal = queryAboutModal();
+  const showAboutModalBtn = queryShowAboutModalBtn();
+  const closeAboutModalBtn = queryCloseAboutModalBtn();
 
-  showAboutDialogButton.addEventListener("click", () => {
-    aboutDialog.showModal();
+  showAboutModalBtn.addEventListener("click", () => {
+    aboutModal.showModal();
     onShow();
   });
 
-  closeAboutDialogButton.addEventListener("click", () => {
-    aboutDialog.close();
+  closeAboutModalBtn.addEventListener("click", () => {
+    aboutModal.close();
   });
 
-  aboutDialog.addEventListener("close", () => {
+  aboutModal.addEventListener("close", () => {
     onClose();
   });
 };

--- a/src/ui/queries.js
+++ b/src/ui/queries.js
@@ -4,21 +4,21 @@
 export const querySpinner = () => document.querySelector(".spinner");
 
 /**
- * Returns the About dialog.
+ * Returns the About modal.
  */
-export const queryAboutDialog = () => document.querySelector(".about-dialog");
+export const queryAboutModal = () => document.querySelector(".about-modal");
 
 /**
- * Returns the "?" (show about dialog) button.
+ * Returns the "?" (show about modal) button.
  */
-export const queryAboutDialogShowBtn = () =>
-  document.querySelector(".about-dialog-show-btn");
+export const queryShowAboutModalBtn = () =>
+  document.querySelector(".about-modal-show-btn");
 
 /**
- * Returns the "X" (close about dialog) button.
+ * Returns the "X" (close about modal) button.
  */
-export const queryAboutDialogCloseBtn = () =>
-  document.querySelector(".about-dialog-close-btn");
+export const queryCloseAboutModalBtn = () =>
+  document.querySelector(".about-modal-close-btn");
 
 /**
  * Returns all guess rows.
@@ -50,4 +50,4 @@ export const queryVirtualKeys = () =>
 /**
  * Returns the first focusable element.
  */
-export const queryFirstFocusableElement = () => queryAboutDialogShowBtn();
+export const queryFirstFocusableElement = () => queryShowAboutModalBtn();

--- a/style/game.css
+++ b/style/game.css
@@ -56,7 +56,7 @@
 
 /* About Button */
 
-.about-dialog-show-btn {
+.about-modal-show-btn {
   --btn-color: var(--dark-gray);
   --btn-size: 25px;
   background-color: transparent;
@@ -205,10 +205,10 @@ virtual-keyboard:focus {
   }
 }
 
-/* About Dialog
+/* About Modal
  * ========================================================================== */
 
-.about-dialog {
+.about-modal {
   border: 1.5px solid var(--black);
   flex-direction: column;
   margin: 0;
@@ -217,12 +217,12 @@ virtual-keyboard:focus {
   padding: 2rem;
 }
 
-.about-dialog[open] {
+.about-modal[open] {
   display: flex;
 }
 
 @media screen and (min-width: 425px) {
-  .about-dialog {
+  .about-modal {
     box-shadow: 0 19px 38px rgb(0 0 0 / 12%), 0 15px 12px rgb(0 0 0 / 22%);
     margin: 0 auto;
     min-height: auto;
@@ -231,28 +231,28 @@ virtual-keyboard:focus {
     transform: translateY(-50%);
   }
 
-  .about-dialog::backdrop {
+  .about-modal::backdrop {
     background-color: rgba(0, 0, 0, 0.5);
   }
 }
 
-/* About Dialog Header */
+/* About Modal Header */
 
-.about-dialog-header {
+.about-modal-header {
   align-items: center;
   display: flex;
   margin-bottom: 3rem;
 }
 
 @media screen and (min-width: 425px) {
-  .about-dialog-header {
+  .about-modal-header {
     margin-bottom: 2rem;
   }
 }
 
 /* Close About Button */
 
-.about-dialog-close-btn {
+.about-modal-close-btn {
   --btn-color: var(--black);
   --btn-size: 32px;
   align-items: center;


### PR DESCRIPTION
## Changelog

- Refactor Virtual Keyboard by breaking it in smaller modules
- Rename all instances of about dialog to the about modal, which is the correct term
- Close the about modal with the Esc key

## Demo

<img width="300" alt="esc on modal" src="https://github.com/user-attachments/assets/41fd0821-c949-4a9c-9466-83f69788e899">