### PR TITLE
feat: dark theme based on user system preference

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -111,7 +111,11 @@ p {
     --wrong-color: var(--yellow-100);
   }
 
-  a:visited {
+  a {
     color: var(--green-100);
+  }
+
+  a:visited {
+    color: var(--magenta-100);
   }
 }

--- a/style/base.css
+++ b/style/base.css
@@ -4,16 +4,31 @@
   --dark-gray: #7d7e7f;
   --green: #91bf63;
   --light-gray: #c4c6c7;
-  --outline-color: #d71ef7;
+  --magenta: #d71ef7;
+  --paper-black: #333333;
   --paper-white: #f2f2f2;
   --red: #c53a50;
   --white: #fdfdff;
   --yellow: #f2b705;
 
+  /* Color Light Scheme */
+  --bg-color: var(--white);
+  --border-color: var(--light-gray);
+  --button-color: var(--light-gray);
+  --correct-color: var(--green);
+  --error-color: var(--red);
+  --game-bg-color: var(--paper-white);
+  --incorrect-color: var(--dark-gray);
+  --inverted-bg-color: var(--text-color);
+  --inverted-text-color: var(--bg-color);
+  --outline-color: var(--magenta);
+  --text-color: var(--black);
+  --wrong-color: var(--yellow);
+
   /* Font */
   --font-size: 1rem;
-  --sans: "Secular One", sans-serif;
-  --serif: "Suez One", serif;
+  --sans-family: "Secular One", sans-serif;
+  --serif-family: "Suez One", serif;
 
   /* Animation */
   --flip-speed: 0.5s;
@@ -26,6 +41,7 @@
 
   /* Sizing */
   --header-height: 42px;
+  --button-size: 25px;
 }
 
 /* Normalization */
@@ -46,9 +62,9 @@ html {
 }
 
 body {
-  background-color: var(--paper-white);
-  color: var(--black);
-  font-family: var(--sans);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--sans-family);
   font-size: var(--font-size);
   height: 100%;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -1,29 +1,39 @@
 :root {
   /* Color Palette */
-  --black: #0d0d0d;
-  --dark-gray: #7d7e7f;
+  --gray-000: #fdfdff;
+  --gray-100: #f2f2f2;
+  --gray-200: #c4c6c7;
+  --gray-300: #7d7e7f;
+  --gray-400: #4d4d4d;
+  --gray-500: #2e2e2e;
+  --gray-600: #0d0d0d;
   --green: #91bf63;
-  --light-gray: #c4c6c7;
   --magenta: #d71ef7;
-  --paper-black: #333333;
-  --paper-white: #f2f2f2;
   --red: #c53a50;
-  --white: #fdfdff;
   --yellow: #f2b705;
 
-  /* Color Light Scheme */
-  --bg-color: var(--white);
-  --border-color: var(--light-gray);
-  --button-color: var(--light-gray);
+  /* Color Scheme */
+  /* --- backgrounds --- */
+  --bg-color: var(--gray-000);
+  --game-bg-color: var(--gray-100);
+  --inverted-bg-color: var(--text-color);
+
+  /* --- borders --- */
+  --border-color: var(--gray-200);
+
+  /* --- buttons ---*/
+  --button-color: var(--gray-200);
+
+  /* --- states --- */
   --correct-color: var(--green);
   --error-color: var(--red);
-  --game-bg-color: var(--paper-white);
-  --incorrect-color: var(--dark-gray);
-  --inverted-bg-color: var(--text-color);
-  --inverted-text-color: var(--bg-color);
+  --incorrect-color: var(--gray-300);
   --outline-color: var(--magenta);
-  --text-color: var(--black);
   --wrong-color: var(--yellow);
+
+  /* --- text --- */
+  --text-color: var(--gray-600);
+  --inverted-text-color: var(--bg-color);
 
   /* Font */
   --font-size: 1rem;

--- a/style/base.css
+++ b/style/base.css
@@ -1,39 +1,34 @@
 :root {
   /* Color Palette */
-  --gray-000: #fdfdff;
-  --gray-100: #f2f2f2;
-  --gray-200: #c4c6c7;
-  --gray-300: #7d7e7f;
-  --gray-400: #4d4d4d;
-  --gray-500: #2e2e2e;
-  --gray-600: #0d0d0d;
-  --green: #91bf63;
-  --magenta: #d71ef7;
-  --red: #c53a50;
-  --yellow: #f2b705;
+  --black-100: #2e2e2e;
+  --black-200: #0d0d0d;
+  --gray-100: #c4c6c7;
+  --gray-200: #7d7e7f;
+  --gray-300: #4d4d4d;
+  --green-100: #80d926;
+  --green-200: #91bf63;
+  --magenta-100: #ec7eff;
+  --magenta-200: #d71ef7;
+  --red-100: #ff405c;
+  --red-200: #c53a50;
+  --white-100: #fdfdff;
+  --white-200: #f2f2f2;
+  --yellow-100: #ffc71b;
+  --yellow-200: #f2b705;
 
   /* Color Scheme */
-  /* --- backgrounds --- */
-  --bg-color: var(--gray-000);
-  --game-bg-color: var(--gray-100);
-  --inverted-bg-color: var(--text-color);
-
-  /* --- borders --- */
-  --border-color: var(--gray-200);
-
-  /* --- buttons ---*/
+  --bg-color: var(--white-100);
+  --border-color: var(--gray-100);
   --button-color: var(--gray-200);
-
-  /* --- states --- */
-  --correct-color: var(--green);
-  --error-color: var(--red);
-  --incorrect-color: var(--gray-300);
-  --outline-color: var(--magenta);
-  --wrong-color: var(--yellow);
-
-  /* --- text --- */
-  --text-color: var(--gray-600);
+  --correct-color: var(--green-200);
+  --error-color: var(--red-200);
+  --incorrect-color: var(--gray-200);
   --inverted-text-color: var(--bg-color);
+  --keyboard-color: var(--gray-100);
+  --main-bg-color: var(--white-200);
+  --outline-color: var(--magenta-200);
+  --text-color: var(--black-200);
+  --wrong-color: var(--yellow-200);
 
   /* Font */
   --font-size: 1rem;
@@ -86,7 +81,7 @@ p {
 
 /* Universal Focus Indicator */
 
-*:focus {
+*:focus-visible {
   outline: 2px solid var(--outline-color);
 }
 
@@ -96,5 +91,27 @@ p {
   * {
     animation-duration: 0s !important;
     transition-duration: 0s !important;
+  }
+}
+
+/* Color Dark Scheme */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: var(--black-100);
+    --border-color: var(--gray-200);
+    --button-color: var(--gray-100);
+    --correct-color: var(--green-100);
+    --error-color: var(--red-100);
+    --incorrect-color: var(--gray-100);
+    --keyboard-color: var(--black-100);
+    --main-bg-color: var(--gray-300);
+    --outline-color: var(--magenta-100);
+    --text-color: var(--white-100);
+    --wrong-color: var(--yellow-100);
+  }
+
+  a:visited {
+    color: var(--green-100);
   }
 }

--- a/style/base.css
+++ b/style/base.css
@@ -1,40 +1,48 @@
 :root {
-  /* Palette */
-  --white: #fdfdff;
-  --paper-white: #f2f2f2;
-  --light-gray: #c4c6c7;
-  --dark-gray: #7d7e7f;
+  /* Color Palette */
   --black: #0d0d0d;
-  --yellow: #f2b705;
+  --dark-gray: #7d7e7f;
   --green: #91bf63;
-  --red: #c53a50;
+  --light-gray: #c4c6c7;
   --outline-color: #d71ef7;
+  --paper-white: #f2f2f2;
+  --red: #c53a50;
+  --white: #fdfdff;
+  --yellow: #f2b705;
+
   /* Font */
-  --serif: "Suez One", serif;
-  --sans: "Secular One", sans-serif;
   --font-size: 1rem;
+  --sans: "Secular One", sans-serif;
+  --serif: "Suez One", serif;
+
   /* Animation */
-  --typing-speed: 50ms;
   --flip-speed: 0.5s;
-  --shake-speed: 300ms;
   --shake-offset: 2.5px;
+  --shake-speed: 300ms;
+  --typing-speed: 50ms;
+  --win-interval: 100ms;
   --win-offset: 2.5rem;
   --win-speed: 300ms;
-  --win-interval: 100ms;
+
   /* Sizing */
   --header-height: 42px;
+}
+
+/* Normalization */
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+  margin: 0;
+  padding: 0;
 }
 
 html {
   box-sizing: border-box;
   font-size: 16px;
   height: 100%;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
+  line-height: 1.15;
 }
 
 body {
@@ -43,14 +51,11 @@ body {
   font-family: var(--sans);
   font-size: var(--font-size);
   height: 100%;
-  margin: 0;
-  padding: 0;
 }
 
-h1,
-h2,
-h3 {
-  margin: 0;
+p {
+  margin: 1rem 0;
+  line-height: 150%;
 }
 
 /* Universal Focus Indicator */

--- a/style/game.css
+++ b/style/game.css
@@ -56,7 +56,7 @@
 /* About Button */
 
 .about-modal-show-btn {
-  --button-color: var(--dark-gray);
+  --button-color: var(--gray-300);
 
   background-color: transparent;
   border-radius: 50%;
@@ -197,14 +197,14 @@ virtual-keyboard {
   padding-bottom: 1rem;
 }
 
-virtual-keyboard:focus {
-  outline: none;
-}
-
 @media screen and (min-width: 375px) {
   virtual-keyboard {
     min-height: 170px;
   }
+}
+
+virtual-keyboard:focus {
+  outline: none;
 }
 
 /* About Modal
@@ -235,6 +235,8 @@ virtual-keyboard:focus {
 /* About Modal Content */
 
 .about-modal-content {
+  background-color: var(--bg-color);
+  color: var(--text-color);
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/style/game.css
+++ b/style/game.css
@@ -56,8 +56,6 @@
 /* About Button */
 
 .about-modal-show-btn {
-  --button-color: var(--gray-300);
-
   background-color: transparent;
   border-radius: 50%;
   border: 2px solid var(--button-color);
@@ -72,7 +70,7 @@
  * ========================================================================== */
 
 .main {
-  background-color: var(--game-bg-color);
+  background-color: var(--main-bg-color);
   display: flex;
   flex-direction: column;
   height: calc(100% - var(--header-height));
@@ -182,7 +180,7 @@
  * ========================================================================== */
 
 virtual-keyboard {
-  --vk-key-bg-color: var(--button-color);
+  --vk-key-bg-color: var(--keyboard-color);
   --vk-key-color: var(--text-color);
   --vk-key-correct-color: var(--correct-color);
   --vk-key-incorrect-color: var(--incorrect-color);

--- a/style/game.css
+++ b/style/game.css
@@ -59,6 +59,7 @@
 .about-modal-show-btn {
   --btn-color: var(--dark-gray);
   --btn-size: 25px;
+
   background-color: transparent;
   border-radius: 50%;
   border: 2px solid var(--btn-color);
@@ -66,11 +67,10 @@
   font-size: 1rem;
   font-weight: bold;
   height: var(--btn-size);
-  padding: 0;
   width: var(--btn-size);
 }
 
-/* Main Section
+/* Main/Board Section
  * ========================================================================== */
 
 .main {
@@ -150,6 +150,7 @@
   border: 1px solid var(--black);
   font-size: 2rem;
   font-weight: bold;
+  line-height: normal;
   text-transform: uppercase;
 }
 
@@ -176,7 +177,7 @@
   background-color: var(--dark-gray);
 }
 
-/* Virtual Keyboard Component
+/* Virtual Keyboard
  * ========================================================================== */
 
 virtual-keyboard {
@@ -210,10 +211,8 @@ virtual-keyboard:focus {
 
 .about-modal {
   border: none;
-  margin: 0;
   min-height: 100%;
   min-width: 100vw;
-  padding: 0;
 }
 
 @media screen and (min-width: 425px) {
@@ -268,6 +267,7 @@ virtual-keyboard:focus {
 .about-modal-close-btn {
   --btn-color: var(--black);
   --btn-size: 32px;
+
   align-items: center;
   background-color: transparent;
   border: 1.5px solid var(--btn-color);
@@ -277,8 +277,6 @@ virtual-keyboard:focus {
   font-weight: bold;
   height: var(--btn-size);
   justify-content: center;
-  margin: 0;
-  padding: 0;
   position: absolute;
   right: 1rem;
   top: 1rem;
@@ -318,6 +316,7 @@ virtual-keyboard:focus {
 
 .color-meaning .box {
   --box-size: 42px;
+
   width: var(--box-size);
   height: var(--box-size);
 }

--- a/style/game.css
+++ b/style/game.css
@@ -6,8 +6,7 @@
 
 .header {
   align-items: center;
-  background-color: var(--white);
-  border-bottom: 1px solid var(--light-gray);
+  border-bottom: 1px solid var(--border-color);
   display: flex;
   height: var(--header-height);
   justify-content: center;
@@ -17,20 +16,20 @@
 
 .wordless-title {
   display: flex;
-  font-family: var(--serif);
+  font-family: var(--serif-family);
   justify-content: center;
 }
 
 .wordless-title span.yellow {
-  color: var(--yellow);
+  color: var(--wrong-color);
 }
 
 .wordless-title span.green {
-  color: var(--green);
+  color: var(--correct-color);
 }
 
 .wordless-title span.gray {
-  color: var(--dark-gray);
+  color: var(--incorrect-color);
 }
 
 /* Spinner */
@@ -57,23 +56,23 @@
 /* About Button */
 
 .about-modal-show-btn {
-  --btn-color: var(--dark-gray);
-  --btn-size: 25px;
+  --button-color: var(--dark-gray);
 
   background-color: transparent;
   border-radius: 50%;
-  border: 2px solid var(--btn-color);
-  color: var(--btn-color);
+  border: 2px solid var(--button-color);
+  color: var(--button-color);
   font-size: 1rem;
   font-weight: bold;
-  height: var(--btn-size);
-  width: var(--btn-size);
+  height: var(--button-size);
+  width: var(--button-size);
 }
 
 /* Main/Board Section
  * ========================================================================== */
 
 .main {
+  background-color: var(--game-bg-color);
   display: flex;
   flex-direction: column;
   height: calc(100% - var(--header-height));
@@ -120,8 +119,8 @@
 }
 
 .guess--invalid > .letter {
-  border: 1px solid var(--red);
-  color: var(--red);
+  border: 1px solid var(--error-color);
+  color: var(--error-color);
   transition-duration: calc(var(--shake-speed) / 2);
   transition-property: border, color;
   transition-timing-function: ease-in;
@@ -139,15 +138,16 @@
 .box {
   align-items: center;
   border-radius: 3px;
-  border: 1px solid var(--light-gray);
+  border: 1px solid var(--border-color);
   display: flex;
   justify-content: center;
 }
 
 .letter {
   animation: typing var(--typing-speed) ease-out;
-  background-color: var(--white);
-  border: 1px solid var(--black);
+  background-color: var(--bg-color);
+  border: 1px solid var(--text-color);
+  color: var(--text-color);
   font-size: 2rem;
   font-weight: bold;
   line-height: normal;
@@ -162,32 +162,33 @@
   transition-timing-function: ease-out;
 }
 
+[class*="letter--"] {
+  color: var(--inverted-text-color);
+}
+
 .letter--correct {
-  color: var(--white);
-  background-color: var(--green);
+  background-color: var(--correct-color);
 }
 
 .letter--wrong {
-  color: var(--white);
-  background-color: var(--yellow);
+  background-color: var(--wrong-color);
 }
 
 .letter--incorrect {
-  color: var(--white);
-  background-color: var(--dark-gray);
+  background-color: var(--incorrect-color);
 }
 
 /* Virtual Keyboard
  * ========================================================================== */
 
 virtual-keyboard {
-  --vk-key-bg-color: var(--light-gray);
-  --vk-key-color: var(--black);
-  --vk-key-correct-color: var(--green);
-  --vk-key-incorrect-color: var(--dark-gray);
-  --vk-key-on-state-color: var(--white);
+  --vk-key-bg-color: var(--button-color);
+  --vk-key-color: var(--text-color);
+  --vk-key-correct-color: var(--correct-color);
+  --vk-key-incorrect-color: var(--incorrect-color);
+  --vk-key-on-state-color: var(--inverted-text-color);
   --vk-key-outline-color: var(--outline-color);
-  --vk-key-wrong-color: var(--yellow);
+  --vk-key-wrong-color: var(--wrong-color);
 
   align-items: flex-end;
   display: flex;
@@ -217,7 +218,7 @@ virtual-keyboard:focus {
 
 @media screen and (min-width: 425px) {
   .about-modal {
-    border: 1.5px solid var(--black);
+    border: 1.5px solid var(--border-color);
     box-shadow: 0 19px 38px rgb(0 0 0 / 12%), 0 15px 12px rgb(0 0 0 / 22%);
     margin: 0 auto;
     min-height: auto;
@@ -265,22 +266,22 @@ virtual-keyboard:focus {
 /* Close About Button */
 
 .about-modal-close-btn {
-  --btn-color: var(--black);
-  --btn-size: 32px;
+  --button-color: var(--text-color);
+  --button-size: 32px;
 
   align-items: center;
   background-color: transparent;
-  border: 1.5px solid var(--btn-color);
-  color: var(--btn-color);
+  border: 1.5px solid var(--button-color);
+  color: var(--button-color);
   display: flex;
   font-size: 1rem;
   font-weight: bold;
-  height: var(--btn-size);
+  height: var(--button-size);
   justify-content: center;
   position: absolute;
   right: 1rem;
   top: 1rem;
-  width: var(--btn-size);
+  width: var(--button-size);
 }
 
 /* Game Instructions */


### PR DESCRIPTION
## Changelog

* The color palette has been refactored by adding new colors for the dark scheme and given a systematic naming convention: `color-name-100`, `color-name-200`, etc.
* Focus outline has been changed from `focus` to `focus-visible`.
* New variables for the color scheme have been added for better scalability.
* Styles for normalization have been added.

## Screenshots

### Game (light/dark)

<img width="318" alt="game-light-scheme" src="https://github.com/user-attachments/assets/96c2a271-7353-4461-b70e-f9a5d31fcc66">
<img width="318" alt="game-dark-scheme" src="https://github.com/user-attachments/assets/f48c4ef1-0afa-41c0-97d9-8d8e8560562d">

### Focus outline (light/dark)

<img width="318" alt="image" src="https://github.com/user-attachments/assets/7ad83397-dcb4-4404-b2a9-87f1ed9d6625">
<img width="318" alt="image" src="https://github.com/user-attachments/assets/01192389-2380-4ea8-9ccb-8c8becb31557">

### About (light/dark)

<img width="318" alt="about-light-scheme" src="https://github.com/user-attachments/assets/c9c848b7-2a2b-47d3-b7d5-ed753efb1225">
<img width="318" alt="about-dark-scheme" src="https://github.com/user-attachments/assets/dd5e74f5-c108-4ae0-89cd-5de9de883d62">

### Link visited (light/dark)

<img width="318" alt="image" src="https://github.com/user-attachments/assets/0fc0680f-99cc-4652-bbda-3b9978649532">
<img width="318" alt="image" src="https://github.com/user-attachments/assets/0df1d5fd-e1f6-468d-aacd-72cf7c1724c7">

## Demo

![dark-scheme](https://github.com/user-attachments/assets/6beb03c1-c906-45b4-a1e6-9b0ff89b20ba)

